### PR TITLE
Add custom provider support and fix terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,7 @@ if (client.supports(Capability.CARRIER)) {
 }
 
 if (client.supports(Capability.EXCHANGE)) {
-  // 支援換開發票
-  await client.invoices.exchange(...);
+  // 支援 B2B 發票交換
 }
 
 // 取得所有支援的能力
@@ -213,7 +212,7 @@ console.log(capabilities);
 | `DONATION` | 捐贈 | ✓ |
 | `ALLOWANCE` | 折讓 | ✓ |
 | `VOID` | 作廢 | ✓ |
-| `EXCHANGE` | 換開 | ✓ |
+| `EXCHANGE` | B2B 交換 | ✓ |
 | `PRINT` | 列印格式 | ✓ |
 
 ## 錯誤處理
@@ -246,11 +245,51 @@ try {
 }
 ```
 
+## 自訂系統商
+
+如果您使用的加值中心尚未內建支援，可以自行實作：
+
+```typescript
+import { Zinvoice, Capability } from '@zentring/zinvoice';
+
+const client = Zinvoice.custom({
+  name: '自訂系統商',
+  capabilities: [Capability.B2C, Capability.QUERY, Capability.LIST],
+  invoices: {
+    issue: async (invoice) => {
+      // 實作開立發票邏輯
+      return {
+        invoiceNumber: InvoiceNumber.create('AA12345678'),
+        invoiceTime: new Date(),
+        randomNumber: '1234',
+        barcode: '...',
+        qrcodeLeft: '...',
+        qrcodeRight: '...',
+      };
+    },
+    findByNumber: async (number) => { /* ... */ },
+    findByOrderId: async (orderId) => { /* ... */ },
+    getStatus: async (numbers) => { /* ... */ },
+    list: async (query) => { /* ... */ },
+  },
+});
+```
+
+**重要：** 註冊的 Capability 必須實作對應的方法，否則會拋出 `ValidationError`：
+
+| Capability | 必須實作 |
+|------------|----------|
+| `B2C` / `B2B` | `invoices.issue` |
+| `VOID` | `invoices.void` |
+| `QUERY` | `invoices.findByNumber`, `findByOrderId`, `getStatus` |
+| `LIST` | `invoices.list` |
+| `ALLOWANCE` | `allowances.issue`, `void`, `findByNumber`, `findByInvoiceNumber`, `getStatus`, `list` |
+
 ## 支援的加值中心
 
 | Provider | 狀態 | 說明 |
 |----------|:----:|------|
-| `Provider.AMEGO` | ✓ | 光貿資訊 |
+| `Provider.AMEGO` | ✓ | 光貿科技 |
 
 ## 測試帳號
 

--- a/src/CustomProvider.test.ts
+++ b/src/CustomProvider.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { Zinvoice } from './Zinvoice.js';
+import { Capability } from './Provider.js';
+import { Invoice } from './domain/invoice/Invoice.js';
+import { InvoiceNumber } from './domain/invoice/InvoiceNumber.js';
+import { InvoiceItem } from './domain/invoice/InvoiceItem.js';
+import { Money } from './domain/shared/Money.js';
+import { OrderId } from './domain/shared/OrderId.js';
+import { Buyer } from './domain/shared/Buyer.js';
+import { ValidationError } from './errors/index.js';
+
+describe('CustomProvider', () => {
+  const createTestInvoice = () =>
+    Invoice.create({
+      orderId: OrderId.create('TEST-001'),
+      buyer: Buyer.anonymous('測試'),
+      items: [
+        InvoiceItem.create({
+          description: '測試商品',
+          quantity: 1,
+          unitPrice: Money.create(100),
+          amount: Money.create(100),
+        }),
+      ],
+    });
+
+  describe('Zinvoice.custom', () => {
+    it('should create custom provider with required handlers', () => {
+      const client = Zinvoice.custom({
+        name: '測試系統商',
+        capabilities: [Capability.B2C, Capability.QUERY, Capability.LIST],
+        invoices: {
+          issue: async () => ({
+            invoiceNumber: InvoiceNumber.create('AA12345678'),
+            invoiceTime: new Date(),
+            randomNumber: '1234',
+            barcode: '',
+            qrcodeLeft: '',
+            qrcodeRight: '',
+          }),
+          findByNumber: async () => null,
+          findByOrderId: async () => null,
+          getStatus: async () => [],
+          list: async () => ({
+            items: [],
+            totalCount: 0,
+            totalPages: 0,
+            currentPage: 1,
+            pageSize: 20,
+            hasNextPage: false,
+            hasPreviousPage: false,
+          }),
+        },
+      });
+
+      expect(client.provider).toBe('custom');
+      expect(client.providerName).toBe('測試系統商');
+      expect(client.isCustom).toBe(true);
+      expect(client.supports(Capability.B2C)).toBe(true);
+      expect(client.supports(Capability.VOID)).toBe(false);
+    });
+
+    it('should throw ValidationError when missing required handlers', () => {
+      expect(() =>
+        Zinvoice.custom({
+          name: '測試系統商',
+          capabilities: [Capability.B2C], // requires issue
+          invoices: {
+            // missing issue handler
+          },
+        })
+      ).toThrow(ValidationError);
+    });
+
+    it('should throw ValidationError when QUERY capability lacks handlers', () => {
+      expect(() =>
+        Zinvoice.custom({
+          name: '測試系統商',
+          capabilities: [Capability.QUERY],
+          invoices: {
+            findByNumber: async () => null,
+            // missing findByOrderId and getStatus
+          },
+        })
+      ).toThrow(ValidationError);
+    });
+
+    it('should call custom issue handler', async () => {
+      let calledWith: Invoice | null = null;
+
+      const client = Zinvoice.custom({
+        name: '測試系統商',
+        capabilities: [Capability.B2C],
+        invoices: {
+          issue: async (invoice) => {
+            calledWith = invoice;
+            return {
+              invoiceNumber: InvoiceNumber.create('BB87654321'),
+              invoiceTime: new Date(),
+              randomNumber: '5678',
+              barcode: 'test-barcode',
+              qrcodeLeft: 'left',
+              qrcodeRight: 'right',
+            };
+          },
+        },
+      });
+
+      const invoice = createTestInvoice();
+      const result = await client.invoices.issue(invoice);
+
+      expect(calledWith).toBe(invoice);
+      expect(result.invoiceNumber.toString()).toBe('BB87654321');
+      expect(result.randomNumber).toBe('5678');
+    });
+
+    it('should throw when calling unimplemented method', async () => {
+      const client = Zinvoice.custom({
+        name: '測試系統商',
+        capabilities: [Capability.B2C],
+        invoices: {
+          issue: async () => ({
+            invoiceNumber: InvoiceNumber.create('AA12345678'),
+            invoiceTime: new Date(),
+            randomNumber: '1234',
+            barcode: '',
+            qrcodeLeft: '',
+            qrcodeRight: '',
+          }),
+        },
+      });
+
+      // void is not in capabilities, should throw UnsupportedCapabilityError
+      await expect(
+        client.invoices.void(InvoiceNumber.create('AA12345678'))
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/CustomProvider.ts
+++ b/src/CustomProvider.ts
@@ -1,0 +1,174 @@
+import { Capability } from './Provider.js';
+import {
+  InvoiceService,
+  IssueInvoiceResult,
+  InvoiceStatusInfo,
+} from './domain/invoice/InvoiceService.js';
+import {
+  AllowanceService,
+  IssueAllowanceResult,
+  AllowanceStatusInfo,
+  AllowanceQuery,
+} from './domain/allowance/AllowanceService.js';
+import { Invoice } from './domain/invoice/Invoice.js';
+import { InvoiceNumber } from './domain/invoice/InvoiceNumber.js';
+import { InvoiceQuery } from './domain/invoice/InvoiceQuery.js';
+import { Allowance } from './domain/allowance/Allowance.js';
+import { PaginatedResult } from './domain/shared/Pagination.js';
+import { ValidationError, UnsupportedCapabilityError } from './errors/index.js';
+
+/**
+ * Custom invoice service handlers
+ */
+export interface CustomInvoiceHandlers {
+  /** 開立發票 (B2C/B2B capability) */
+  issue?: (invoice: Invoice) => Promise<IssueInvoiceResult>;
+  /** 作廢發票 (VOID capability) */
+  void?: (invoiceNumber: InvoiceNumber) => Promise<void>;
+  /** 依發票號碼查詢 (QUERY capability) */
+  findByNumber?: (invoiceNumber: InvoiceNumber) => Promise<Invoice | null>;
+  /** 依訂單編號查詢 (QUERY capability) */
+  findByOrderId?: (orderId: string) => Promise<Invoice | null>;
+  /** 查詢發票狀態 (QUERY capability) */
+  getStatus?: (invoiceNumbers: InvoiceNumber[]) => Promise<InvoiceStatusInfo[]>;
+  /** 發票列表 (LIST capability) */
+  list?: (query: InvoiceQuery) => Promise<PaginatedResult<Invoice>>;
+}
+
+/**
+ * Custom allowance service handlers
+ */
+export interface CustomAllowanceHandlers {
+  /** 開立折讓 (ALLOWANCE capability) */
+  issue?: (allowance: Allowance) => Promise<IssueAllowanceResult>;
+  /** 作廢折讓 (ALLOWANCE capability) */
+  void?: (allowanceNumber: string) => Promise<void>;
+  /** 依折讓單號查詢 (ALLOWANCE capability) */
+  findByNumber?: (allowanceNumber: string) => Promise<Allowance | null>;
+  /** 依發票號碼查詢折讓 (ALLOWANCE capability) */
+  findByInvoiceNumber?: (invoiceNumber: InvoiceNumber) => Promise<Allowance[]>;
+  /** 查詢折讓狀態 (ALLOWANCE capability) */
+  getStatus?: (allowanceNumbers: string[]) => Promise<AllowanceStatusInfo[]>;
+  /** 折讓列表 (ALLOWANCE capability) */
+  list?: (query: AllowanceQuery) => Promise<PaginatedResult<Allowance>>;
+}
+
+/**
+ * Configuration for custom provider
+ */
+export interface CustomProviderConfig {
+  /** 自訂系統商名稱 */
+  name: string;
+  /** 支援的能力 */
+  capabilities: Capability[];
+  /** 發票服務實作 */
+  invoices?: CustomInvoiceHandlers;
+  /** 折讓服務實作 */
+  allowances?: CustomAllowanceHandlers;
+}
+
+/**
+ * Capability to required handlers mapping
+ */
+const CAPABILITY_REQUIREMENTS: Record<Capability, { invoices?: (keyof CustomInvoiceHandlers)[]; allowances?: (keyof CustomAllowanceHandlers)[] }> = {
+  [Capability.B2C]: { invoices: ['issue'] },
+  [Capability.B2B]: { invoices: ['issue'] },
+  [Capability.CARRIER]: {}, // Part of issue, no separate handler
+  [Capability.DONATION]: {}, // Part of issue, no separate handler
+  [Capability.VOID]: { invoices: ['void'] },
+  [Capability.QUERY]: { invoices: ['findByNumber', 'findByOrderId', 'getStatus'] },
+  [Capability.LIST]: { invoices: ['list'] },
+  [Capability.ALLOWANCE]: { allowances: ['issue', 'void', 'findByNumber', 'findByInvoiceNumber', 'getStatus', 'list'] },
+  [Capability.EXCHANGE]: {}, // TODO: Add exchange handlers when implemented
+  [Capability.PRINT]: {}, // Part of issue result, no separate handler
+};
+
+/**
+ * Validate that all required handlers are implemented for the given capabilities
+ */
+export function validateCustomProviderConfig(config: CustomProviderConfig): void {
+  const missingHandlers: string[] = [];
+
+  for (const capability of config.capabilities) {
+    const requirements = CAPABILITY_REQUIREMENTS[capability];
+
+    // Check invoice handlers
+    if (requirements.invoices) {
+      for (const handler of requirements.invoices) {
+        if (!config.invoices?.[handler]) {
+          missingHandlers.push(`invoices.${handler} (required for ${capability})`);
+        }
+      }
+    }
+
+    // Check allowance handlers
+    if (requirements.allowances) {
+      for (const handler of requirements.allowances) {
+        if (!config.allowances?.[handler]) {
+          missingHandlers.push(`allowances.${handler} (required for ${capability})`);
+        }
+      }
+    }
+  }
+
+  if (missingHandlers.length > 0) {
+    throw new ValidationError(
+      'customProvider',
+      `Missing required handlers for registered capabilities:\n  - ${missingHandlers.join('\n  - ')}`
+    );
+  }
+}
+
+/**
+ * Create a custom invoice service from handlers
+ */
+export function createCustomInvoiceService(
+  providerName: string,
+  capabilities: Set<Capability>,
+  handlers: CustomInvoiceHandlers = {}
+): InvoiceService {
+  const notImplemented = (method: string, capability: Capability) => {
+    return async () => {
+      if (!capabilities.has(capability)) {
+        throw new UnsupportedCapabilityError(capability, providerName as any);
+      }
+      throw new Error(`${providerName}: ${method} is not implemented`);
+    };
+  };
+
+  return {
+    issue: handlers.issue ?? notImplemented('issue', Capability.B2C) as any,
+    void: handlers.void ?? notImplemented('void', Capability.VOID) as any,
+    findByNumber: handlers.findByNumber ?? notImplemented('findByNumber', Capability.QUERY) as any,
+    findByOrderId: handlers.findByOrderId ?? notImplemented('findByOrderId', Capability.QUERY) as any,
+    getStatus: handlers.getStatus ?? notImplemented('getStatus', Capability.QUERY) as any,
+    list: handlers.list ?? notImplemented('list', Capability.LIST) as any,
+  };
+}
+
+/**
+ * Create a custom allowance service from handlers
+ */
+export function createCustomAllowanceService(
+  providerName: string,
+  capabilities: Set<Capability>,
+  handlers: CustomAllowanceHandlers = {}
+): AllowanceService {
+  const notImplemented = (method: string) => {
+    return async () => {
+      if (!capabilities.has(Capability.ALLOWANCE)) {
+        throw new UnsupportedCapabilityError(Capability.ALLOWANCE, providerName);
+      }
+      throw new Error(`${providerName}: ${method} is not implemented`);
+    };
+  };
+
+  return {
+    issue: handlers.issue ?? notImplemented('issue') as any,
+    void: handlers.void ?? notImplemented('void') as any,
+    findByNumber: handlers.findByNumber ?? notImplemented('findByNumber') as any,
+    findByInvoiceNumber: handlers.findByInvoiceNumber ?? notImplemented('findByInvoiceNumber') as any,
+    getStatus: handlers.getStatus ?? notImplemented('getStatus') as any,
+    list: handlers.list ?? notImplemented('list') as any,
+  };
+}

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -2,7 +2,7 @@
  * Supported e-invoice providers (加值中心)
  */
 export enum Provider {
-  /** 光貿資訊 */
+  /** 光貿科技 */
   AMEGO = 'amego',
 }
 
@@ -22,7 +22,7 @@ export enum Capability {
   ALLOWANCE = 'allowance',
   /** 作廢 */
   VOID = 'void',
-  /** 換開發票 */
+  /** B2B 發票交換 (透過大平台傳遞確認) */
   EXCHANGE = 'exchange',
   /** 列印格式輸出 */
   PRINT = 'print',
@@ -54,5 +54,5 @@ export const PROVIDER_CAPABILITIES: Record<Provider, Set<Capability>> = {
  * Provider display names
  */
 export const PROVIDER_NAMES: Record<Provider, string> = {
-  [Provider.AMEGO]: '光貿資訊',
+  [Provider.AMEGO]: '光貿科技',
 };

--- a/src/Zinvoice.ts
+++ b/src/Zinvoice.ts
@@ -12,6 +12,12 @@ import { InvoiceService } from './domain/invoice/InvoiceService.js';
 import { AllowanceService } from './domain/allowance/AllowanceService.js';
 import { AmegoInvoiceService } from './infrastructure/amego/AmegoInvoiceService.js';
 import { AmegoAllowanceService } from './infrastructure/amego/AmegoAllowanceService.js';
+import {
+  CustomProviderConfig,
+  validateCustomProviderConfig,
+  createCustomInvoiceService,
+  createCustomAllowanceService,
+} from './CustomProvider.js';
 
 /**
  * Zinvoice client configuration
@@ -36,20 +42,24 @@ export interface ZinvoiceConfig {
  * Provides a unified interface across different e-invoice providers.
  */
 export class Zinvoice {
-  private readonly _provider: Provider;
+  private readonly _provider: Provider | 'custom';
+  private readonly _providerName: string;
   private readonly _invoiceService: InvoiceService;
   private readonly _allowanceService: AllowanceService;
   private readonly _capabilities: Set<Capability>;
 
   private constructor(
-    provider: Provider,
+    provider: Provider | 'custom',
+    providerName: string,
+    capabilities: Set<Capability>,
     invoiceService: InvoiceService,
     allowanceService: AllowanceService
   ) {
     this._provider = provider;
+    this._providerName = providerName;
+    this._capabilities = capabilities;
     this._invoiceService = invoiceService;
     this._allowanceService = allowanceService;
-    this._capabilities = PROVIDER_CAPABILITIES[provider];
   }
 
   /**
@@ -78,7 +88,64 @@ export class Zinvoice {
     const invoiceService = new AmegoInvoiceService(amegoConfig);
     const allowanceService = new AmegoAllowanceService(amegoConfig);
 
-    return new Zinvoice(Provider.AMEGO, invoiceService, allowanceService);
+    return new Zinvoice(
+      Provider.AMEGO,
+      PROVIDER_NAMES[Provider.AMEGO],
+      PROVIDER_CAPABILITIES[Provider.AMEGO],
+      invoiceService,
+      allowanceService
+    );
+  }
+
+  /**
+   * Create a custom Zinvoice client with user-provided handlers
+   *
+   * @example
+   * ```typescript
+   * const client = Zinvoice.custom({
+   *   name: '自訂系統商',
+   *   capabilities: [Capability.B2C, Capability.QUERY, Capability.LIST],
+   *   invoices: {
+   *     issue: async (invoice) => {
+   *       // 實作開立發票邏輯
+   *       return { invoiceNumber, invoiceTime, randomNumber };
+   *     },
+   *     findByNumber: async (number) => {
+   *       // 實作查詢邏輯
+   *       return invoice;
+   *     },
+   *     findByOrderId: async (orderId) => { ... },
+   *     getStatus: async (numbers) => { ... },
+   *     list: async (query) => { ... },
+   *   },
+   * });
+   * ```
+   *
+   * @throws {ValidationError} If required handlers are not implemented for registered capabilities
+   */
+  static custom(config: CustomProviderConfig): Zinvoice {
+    // Validate that all required handlers are implemented
+    validateCustomProviderConfig(config);
+
+    const capabilities = new Set(config.capabilities);
+    const invoiceService = createCustomInvoiceService(
+      config.name,
+      capabilities,
+      config.invoices
+    );
+    const allowanceService = createCustomAllowanceService(
+      config.name,
+      capabilities,
+      config.allowances
+    );
+
+    return new Zinvoice(
+      'custom',
+      config.name,
+      capabilities,
+      invoiceService,
+      allowanceService
+    );
   }
 
   /**
@@ -97,8 +164,9 @@ export class Zinvoice {
 
   /**
    * Get the current provider
+   * Returns 'custom' for custom providers
    */
-  get provider(): Provider {
+  get provider(): Provider | 'custom' {
     return this._provider;
   }
 
@@ -106,7 +174,7 @@ export class Zinvoice {
    * Get the provider display name
    */
   get providerName(): string {
-    return PROVIDER_NAMES[this._provider];
+    return this._providerName;
   }
 
   /**
@@ -128,7 +196,14 @@ export class Zinvoice {
    */
   requireCapability(capability: Capability): void {
     if (!this.supports(capability)) {
-      throw new UnsupportedCapabilityError(capability, this._provider);
+      throw new UnsupportedCapabilityError(capability, this._providerName);
     }
+  }
+
+  /**
+   * Check if this is a custom provider
+   */
+  get isCustom(): boolean {
+    return this._provider === 'custom';
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,11 @@ export {
   PROVIDER_CAPABILITIES,
   PROVIDER_NAMES,
 } from './Provider.js';
+export {
+  type CustomProviderConfig,
+  type CustomInvoiceHandlers,
+  type CustomAllowanceHandlers,
+} from './CustomProvider.js';
 
 // Domain layer exports - Value Objects
 export {


### PR DESCRIPTION
## Features
- Add `Zinvoice.custom()` for user-defined providers
- Capability-based validation ensures required handlers are implemented
- Throws `ValidationError` if capability registered but handler missing

## Fixes
- EXCHANGE: 換開 → B2B 發票交換 (透過大平台傳遞確認)
- AMEGO: 光貿資訊 → 光貿科技

## Tests
- 67 tests passing (5 new tests for CustomProvider)