### PR TITLE
Fix carrier/donation validation error on invoice query

### DIFF
--- a/scripts/test-issue-b2c.ts
+++ b/scripts/test-issue-b2c.ts
@@ -1,0 +1,85 @@
+/**
+ * 測試開立 B2C 發票
+ *
+ * 光貿測試帳號：
+ * - 統編: 12345678
+ * - API Key: sHeq7t8G1wiQvhAuIM27
+ */
+import {
+  Zinvoice,
+  Provider,
+  Invoice,
+  InvoiceItem,
+  Money,
+  OrderId,
+  Buyer,
+  Carrier,
+} from '../src/index.js';
+
+const client = Zinvoice.create({
+  provider: Provider.AMEGO,
+  sellerTaxId: '12345678',
+  apiKey: 'sHeq7t8G1wiQvhAuIM27',
+});
+
+async function main() {
+  console.log('═'.repeat(60));
+  console.log('       測試開立 B2C 發票');
+  console.log('═'.repeat(60));
+
+  // 產生唯一訂單編號
+  const orderId = `TEST-${Date.now()}`;
+
+  console.log(`\n訂單編號: ${orderId}`);
+
+  // 建立發票
+  const invoice = Invoice.create({
+    orderId: OrderId.create(orderId),
+    buyer: Buyer.anonymous('測試客人'),
+    items: [
+      InvoiceItem.create({
+        description: '測試商品 A',
+        quantity: 2,
+        unitPrice: Money.create(100),
+        amount: Money.create(200),
+      }),
+      InvoiceItem.create({
+        description: '測試商品 B',
+        quantity: 1,
+        unitPrice: Money.create(50),
+        amount: Money.create(50),
+      }),
+    ],
+    carrier: Carrier.mobile('/ABC+123'), // 測試用手機條碼
+  });
+
+  console.log(`\n發票內容:`);
+  console.log(`  買方: ${invoice.buyer.name}`);
+  console.log(`  載具: ${invoice.carrier.id}`);
+  console.log(`  商品數: ${invoice.items.length}`);
+  console.log(`  總金額: $${invoice.calculateTotalAmount().toNumber()}`);
+
+  console.log('\n開立發票中...\n');
+
+  try {
+    const result = await client.invoices.issue(invoice);
+
+    console.log('✅ 發票開立成功！');
+    console.log(`\n  發票號碼: ${result.invoiceNumber.toString()}`);
+    console.log(`  隨機碼: ${result.randomNumber}`);
+    console.log(`  開立時間: ${result.invoiceTime.toISOString()}`);
+    console.log(`  條碼: ${result.barcode}`);
+    console.log(`  QR Code 左: ${result.qrcodeLeft.substring(0, 50)}...`);
+    console.log(`  QR Code 右: ${result.qrcodeRight.substring(0, 50)}...`);
+
+    if (result.printData) {
+      console.log(`  列印資料: (${result.printData.length} bytes base64)`);
+    }
+  } catch (error) {
+    console.error('❌ 發票開立失敗:', error);
+  }
+
+  console.log('\n' + '═'.repeat(60));
+}
+
+main().catch(console.error);

--- a/src/domain/invoice/Invoice.ts
+++ b/src/domain/invoice/Invoice.ts
@@ -174,6 +174,39 @@ export class Invoice {
   }
 
   /**
+   * Reconstruct an Invoice from persistence/API without validation
+   *
+   * Use this when reading existing invoices from database or API.
+   * Skips validation rules that only apply when creating new invoices.
+   */
+  static reconstruct(props: CreateInvoiceProps): Invoice {
+    // Minimal validation - just check items exist
+    if (!props.items || props.items.length === 0) {
+      throw new ValidationError('items', 'At least one item is required');
+    }
+
+    const taxType = Invoice.determineTaxType(props.items);
+    const isB2B = props.buyer.isCompany;
+
+    return new Invoice(
+      props.orderId,
+      props.buyer,
+      props.items,
+      props.carrier ?? Carrier.none(),
+      props.donation ?? Donation.none(),
+      props.remark?.trim() ?? '',
+      props.trackApiCode?.trim() ?? '',
+      taxType,
+      props.customsClearanceMark,
+      props.zeroTaxRateReason,
+      props.brandName?.trim(),
+      props.pricesIncludeTax ?? true,
+      InvoiceStatus.PENDING,
+      isB2B ? InvoiceType.B2B_ISSUE : InvoiceType.B2C_ISSUE
+    );
+  }
+
+  /**
    * Determine overall tax type from items
    */
   private static determineTaxType(items: InvoiceItem[]): TaxType {

--- a/src/infrastructure/amego/AmegoInvoiceRepository.ts
+++ b/src/infrastructure/amego/AmegoInvoiceRepository.ts
@@ -373,7 +373,9 @@ export class AmegoInvoiceRepository implements InvoiceRepository {
       ? Donation.tryCreate(response.npoban)
       : Donation.none();
 
-    const invoice = Invoice.create({
+    // Use reconstruct to skip validation (e.g., carrier+donation exclusivity)
+    // since we're reading existing data from the API
+    const invoice = Invoice.reconstruct({
       orderId: OrderId.create(response.order_id || response.invoice_number),
       buyer,
       items,
@@ -427,7 +429,9 @@ export class AmegoInvoiceRepository implements InvoiceRepository {
       ? Donation.tryCreate(item.npoban)
       : Donation.none();
 
-    const invoice = Invoice.create({
+    // Use reconstruct to skip validation (e.g., carrier+donation exclusivity)
+    // since we're reading existing data from the API
+    const invoice = Invoice.reconstruct({
       orderId: OrderId.create(item.order_id || item.invoice_number),
       buyer,
       items: [placeholderItem],


### PR DESCRIPTION
## 問題

查詢發票列表時，部分發票同時有 carrier 和 donation 資料，觸發驗證錯誤：
```
Validation error on carrier: Cannot have both carrier and donation on the same invoice
```

## 解決方案

新增 `Invoice.reconstruct()` 方法，用於從 API 讀取既有發票時跳過開立驗證規則。

## 變更

- `Invoice.ts`: 新增 `reconstruct()` 靜態方法
- `AmegoInvoiceRepository.ts`: 查詢時改用 `reconstruct()` 

Fixes #5