### PR TITLE
fix: 修正查詢發票列表時 invoiceTime 解析失敗

### DIFF
--- a/src/infrastructure/amego/AmegoInvoiceRepository.ts
+++ b/src/infrastructure/amego/AmegoInvoiceRepository.ts
@@ -385,7 +385,10 @@ export class AmegoInvoiceRepository implements InvoiceRepository {
     });
 
     const invoiceNumber = InvoiceNumber.create(response.invoice_number);
-    const invoiceTime = AmegoMapper.parseIsoDate(response.invoice_time);
+    const invoiceTime = AmegoMapper.parseDateAndTime(
+      response.invoice_date,
+      response.invoice_time
+    );
 
     invoice.setInvoiceNumber(invoiceNumber, invoiceTime, response.random_number);
     invoice.updateStatus(AmegoMapper.toInvoiceStatus(response.invoice_status));
@@ -441,8 +444,10 @@ export class AmegoInvoiceRepository implements InvoiceRepository {
     });
 
     const invoiceNumber = InvoiceNumber.create(item.invoice_number);
-    // invoice_date 是 YYYYMMDD number，invoice_time 是 ISO string
-    const invoiceTime = AmegoMapper.parseIsoDate(item.invoice_time);
+    const invoiceTime = AmegoMapper.parseDateAndTime(
+      item.invoice_date,
+      item.invoice_time
+    );
 
     invoice.setInvoiceNumber(invoiceNumber, invoiceTime, item.random_number);
     invoice.updateStatus(AmegoMapper.toInvoiceStatus(item.invoice_status));

--- a/src/infrastructure/amego/AmegoMapper.ts
+++ b/src/infrastructure/amego/AmegoMapper.ts
@@ -736,4 +736,18 @@ export class AmegoMapper {
   static parseIsoDate(isoStr: string): Date {
     return new Date(isoStr);
   }
+
+  /**
+   * Parse separate date (YYYYMMDD) and time (HH:mm:ss) to Date
+   *
+   * API 回傳的 invoice_date 和 invoice_time 是分開的，需要組合後解析
+   */
+  static parseDateAndTime(dateValue: string | number, timeStr: string): Date {
+    const dateStr = String(dateValue);
+    const year = dateStr.substring(0, 4);
+    const month = dateStr.substring(4, 6);
+    const day = dateStr.substring(6, 8);
+    const isoStr = `${year}-${month}-${day}T${timeStr}`;
+    return new Date(isoStr);
+  }
 }


### PR DESCRIPTION
## Summary
- 新增 `AmegoMapper.parseDateAndTime()` 方法，組合分離的日期時間格式
- 修正 `mapQueryResponse` 和 `mapListItemResponse` 使用新方法解析 invoiceTime

## Root Cause
API 回傳的 `invoice_date` (YYYYMMDD) 和 `invoice_time` (HH:mm:ss) 是分開的，
但原本直接把 `"17:35:47"` 丟給 `new Date()` 導致 Invalid Date。

## Test Plan
- [x] 單元測試通過 (67/67)
- [x] Build 成功

Closes #9