### PR TITLE
fix: 含稅時 SalesAmount 送出未稅金額

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zinvoice",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zinvoice",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zentring/zinvoice",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Taiwan e-invoice integration SDK for value-added centers (加值中心電子發票整合套件)",
   "keywords": [
     "taiwan",

--- a/src/infrastructure/amego/AmegoMapper.ts
+++ b/src/infrastructure/amego/AmegoMapper.ts
@@ -468,7 +468,8 @@ export class AmegoMapper {
         : invoice.buyer.taxId.toString(),
       BuyerName: invoice.buyer.name,
       ProductItem: invoice.items.map(AmegoMapper.toInvoiceItemPayload),
-      SalesAmount: salesAmount,
+      // 含稅時 SalesAmount 應送未稅金額，確保 SalesAmount + TaxAmount = TotalAmount
+      SalesAmount: invoice.pricesIncludeTax ? salesAmount - taxAmount : salesAmount,
       FreeTaxSalesAmount: freeTaxSalesAmount,
       ZeroTaxSalesAmount: zeroTaxSalesAmount,
       TaxType: AmegoMapper.toApiTaxType(invoice.taxType),


### PR DESCRIPTION
## Summary
- 修正 `AmegoMapper.toInvoicePayload` 含稅時 `SalesAmount` 送出含稅金額導致 API 3040174 錯誤
- 升版至 0.1.4

Closes #12